### PR TITLE
Update rds db group name now calling the subnet ids from output, it s…

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -92,8 +92,8 @@ module "vpc_endpoints" {
     tags = local.db_tags
 }
 
-resource "aws_db_subnet_group" "kiu-db-subnet-group" {
-  name       = "kiu-db-subnet-group"
+resource "aws_db_subnet_group" "kiu-db-infrastructure" {
+  name       = "kiu-db-infrastructure"
   subnet_ids = module.vpc.private_subnets
 
   tags = {
@@ -234,7 +234,7 @@ module "aurora" {
     }
 
     vpc_id               = module.vpc.vpc_id
-    db_subnet_group_name = module.vpc.database_subnet_group_name
+    db_subnet_group_name = aws_db_subnet_group.kiu-db-infrastructure.name
     security_group_rules = {
     vpc_ingress = {
         cidr_blocks = module.vpc.private_subnets_cidr_blocks

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -35,3 +35,7 @@ output "repository_url" {
   description = "The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`)"
   value       = module.ecr.repository_url
 }
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}


### PR DESCRIPTION
## Previous commit didnt fix the issue, seems the db group name, was not correctly added, and even couldnt find the private subnet ids. 

### Now adding the outputs update, and updating the naming on the resource, it should fix it. 

# Lets go ! 